### PR TITLE
Sponsoring via PayPal MoneyPool

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,4 @@
 # These are supported funding model platforms
 
 github: cremich
+custom: ["https://www.paypal.com/pools/c/8yGs7i3cOe"]


### PR DESCRIPTION
This PR will add a link to a PayPal money pool to the funding configuration. Allowing a sponsor to choose whether he wants to send the donation via Github or via a PayPal money pool