### PR TITLE
fix: update outdated stack test snapshot

### DIFF
--- a/test/pool-management/__snapshots__/stack.test.ts.snap
+++ b/test/pool-management/__snapshots__/stack.test.ts.snap
@@ -10,6 +10,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters21b0c3766d09a189f3963f3485c07ea48a0eda7f74a50d561eb3f65618062abcArtifactHash6DE4ADA7": Object {
+      "Description": "Artifact hash for asset \\"21b0c3766d09a189f3963f3485c07ea48a0eda7f74a50d561eb3f65618062abc\\"",
+      "Type": "String",
+    },
+    "AssetParameters21b0c3766d09a189f3963f3485c07ea48a0eda7f74a50d561eb3f65618062abcS3Bucket96F9F4D3": Object {
+      "Description": "S3 bucket for asset \\"21b0c3766d09a189f3963f3485c07ea48a0eda7f74a50d561eb3f65618062abc\\"",
+      "Type": "String",
+    },
+    "AssetParameters21b0c3766d09a189f3963f3485c07ea48a0eda7f74a50d561eb3f65618062abcS3VersionKeyD1EB059F": Object {
+      "Description": "S3 key for asset version \\"21b0c3766d09a189f3963f3485c07ea48a0eda7f74a50d561eb3f65618062abc\\"",
+      "Type": "String",
+    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -20,18 +32,6 @@ Object {
     },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24S3VersionKeyB0F28861": Object {
       "Description": "S3 key for asset version \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
-      "Type": "String",
-    },
-    "AssetParameterse687e32ef3966bde3f1c811d7697d790ba796f7b862b3d3aeab74bfa10ec73b9ArtifactHashE4C864DC": Object {
-      "Description": "Artifact hash for asset \\"e687e32ef3966bde3f1c811d7697d790ba796f7b862b3d3aeab74bfa10ec73b9\\"",
-      "Type": "String",
-    },
-    "AssetParameterse687e32ef3966bde3f1c811d7697d790ba796f7b862b3d3aeab74bfa10ec73b9S3Bucket2762AFD3": Object {
-      "Description": "S3 bucket for asset \\"e687e32ef3966bde3f1c811d7697d790ba796f7b862b3d3aeab74bfa10ec73b9\\"",
-      "Type": "String",
-    },
-    "AssetParameterse687e32ef3966bde3f1c811d7697d790ba796f7b862b3d3aeab74bfa10ec73b9S3VersionKey3B7344ED": Object {
-      "Description": "S3 key for asset version \\"e687e32ef3966bde3f1c811d7697d790ba796f7b862b3d3aeab74bfa10ec73b9\\"",
       "Type": "String",
     },
   },
@@ -219,7 +219,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameterse687e32ef3966bde3f1c811d7697d790ba796f7b862b3d3aeab74bfa10ec73b9S3Bucket2762AFD3",
+            "Ref": "AssetParameters21b0c3766d09a189f3963f3485c07ea48a0eda7f74a50d561eb3f65618062abcS3Bucket96F9F4D3",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -232,7 +232,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameterse687e32ef3966bde3f1c811d7697d790ba796f7b862b3d3aeab74bfa10ec73b9S3VersionKey3B7344ED",
+                          "Ref": "AssetParameters21b0c3766d09a189f3963f3485c07ea48a0eda7f74a50d561eb3f65618062abcS3VersionKeyD1EB059F",
                         },
                       ],
                     },
@@ -245,7 +245,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameterse687e32ef3966bde3f1c811d7697d790ba796f7b862b3d3aeab74bfa10ec73b9S3VersionKey3B7344ED",
+                          "Ref": "AssetParameters21b0c3766d09a189f3963f3485c07ea48a0eda7f74a50d561eb3f65618062abcS3VersionKeyD1EB059F",
                         },
                       ],
                     },


### PR DESCRIPTION
# Update stack test snapshot

## Description

The stack test was failing locally and in the CI workflow. This is due to an outdated snapshot file with differing hash values. Since these hashes are likely to change often a different approach might be to [ignore them](https://lanwen.ru/posts/ignore-jest-snapshot-diffs/). Not sure though if this would overly reduce the test quality in this case.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
By re-running stack.test.ts

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
