### PR TITLE
fix: correct version for codecommit dependency in package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -276,186 +276,19 @@
         },
         "yaml": {
           "version": "1.10.2",
-          "bundled": true
+          "resolved": false
         }
       }
     },
     "@aws-cdk/aws-codecommit": {
-      "version": "1.99.0",
-      "resolved": "https://dflds.jfrog.io/dflds/api/npm/npm-dfl/@aws-cdk/aws-codecommit/-/aws-codecommit-1.99.0.tgz",
-      "integrity": "sha1-evoPpDgNDnETJkqp4XYyWR4zxng=",
+      "version": "1.98.0",
+      "resolved": "https://dflds.jfrog.io/dflds/api/npm/npm-dfl/@aws-cdk/aws-codecommit/-/aws-codecommit-1.98.0.tgz",
+      "integrity": "sha1-KY7P8F6Si7LYsaMgBU0exAHOtXA=",
       "requires": {
-        "@aws-cdk/aws-events": "1.99.0",
-        "@aws-cdk/aws-iam": "1.99.0",
-        "@aws-cdk/core": "1.99.0",
+        "@aws-cdk/aws-events": "1.98.0",
+        "@aws-cdk/aws-iam": "1.98.0",
+        "@aws-cdk/core": "1.98.0",
         "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "@aws-cdk/aws-events": {
-          "version": "1.99.0",
-          "resolved": "https://dflds.jfrog.io/dflds/api/npm/npm-dfl/@aws-cdk/aws-events/-/aws-events-1.99.0.tgz",
-          "integrity": "sha1-9KBBsWiTsaGbk19Ypo56/XQb0Bw=",
-          "requires": {
-            "@aws-cdk/aws-iam": "1.99.0",
-            "@aws-cdk/core": "1.99.0",
-            "constructs": "^3.3.69"
-          }
-        },
-        "@aws-cdk/aws-iam": {
-          "version": "1.99.0",
-          "resolved": "https://dflds.jfrog.io/dflds/api/npm/npm-dfl/@aws-cdk/aws-iam/-/aws-iam-1.99.0.tgz",
-          "integrity": "sha1-Bv9g5E8qRss0WKuwQcSzfvst5aE=",
-          "requires": {
-            "@aws-cdk/core": "1.99.0",
-            "@aws-cdk/region-info": "1.99.0",
-            "constructs": "^3.3.69"
-          }
-        },
-        "@aws-cdk/cloud-assembly-schema": {
-          "version": "1.99.0",
-          "resolved": "https://dflds.jfrog.io/dflds/api/npm/npm-dfl/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.99.0.tgz",
-          "integrity": "sha1-h6aGTNbTzRA7bRVg5gubptcuBDQ=",
-          "requires": {
-            "jsonschema": "^1.4.0",
-            "semver": "^7.3.5"
-          },
-          "dependencies": {
-            "jsonschema": {
-              "version": "1.4.0",
-              "bundled": true
-            },
-            "lru-cache": {
-              "version": "6.0.0",
-              "bundled": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "semver": {
-              "version": "7.3.5",
-              "bundled": true,
-              "requires": {
-                "lru-cache": "^6.0.0"
-              }
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "@aws-cdk/core": {
-          "version": "1.99.0",
-          "resolved": "https://dflds.jfrog.io/dflds/api/npm/npm-dfl/@aws-cdk/core/-/core-1.99.0.tgz",
-          "integrity": "sha1-Mw9tqwwzl1viH+fWIGXXVAAvHlc=",
-          "requires": {
-            "@aws-cdk/cloud-assembly-schema": "1.99.0",
-            "@aws-cdk/cx-api": "1.99.0",
-            "@aws-cdk/region-info": "1.99.0",
-            "@balena/dockerignore": "^1.0.2",
-            "constructs": "^3.3.69",
-            "fs-extra": "^9.1.0",
-            "ignore": "^5.1.8",
-            "minimatch": "^3.0.4"
-          },
-          "dependencies": {
-            "@balena/dockerignore": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "at-least-node": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "1.1.11",
-              "bundled": true,
-              "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "fs-extra": {
-              "version": "9.1.0",
-              "bundled": true,
-              "requires": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-              }
-            },
-            "graceful-fs": {
-              "version": "4.2.6",
-              "bundled": true
-            },
-            "ignore": {
-              "version": "5.1.8",
-              "bundled": true
-            },
-            "jsonfile": {
-              "version": "6.1.0",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.6",
-                "universalify": "^2.0.0"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            },
-            "universalify": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "@aws-cdk/cx-api": {
-          "version": "1.99.0",
-          "resolved": "https://dflds.jfrog.io/dflds/api/npm/npm-dfl/@aws-cdk/cx-api/-/cx-api-1.99.0.tgz",
-          "integrity": "sha1-oFcxIRJbJ2qkQ7XMnVGbxRj8IfM=",
-          "requires": {
-            "@aws-cdk/cloud-assembly-schema": "1.99.0",
-            "semver": "^7.3.5"
-          },
-          "dependencies": {
-            "lru-cache": {
-              "version": "6.0.0",
-              "bundled": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "semver": {
-              "version": "7.3.5",
-              "bundled": true,
-              "requires": {
-                "lru-cache": "^6.0.0"
-              }
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "@aws-cdk/region-info": {
-          "version": "1.99.0",
-          "resolved": "https://dflds.jfrog.io/dflds/api/npm/npm-dfl/@aws-cdk/region-info/-/region-info-1.99.0.tgz",
-          "integrity": "sha1-ZtC+Wx1YoDVx14XBiAfFSJ03OYs="
-        }
       }
     },
     "@aws-cdk/aws-codeguruprofiler": {
@@ -484,7 +317,7 @@
       "dependencies": {
         "punycode": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": false
         }
       }
     },
@@ -558,11 +391,11 @@
       "dependencies": {
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -570,11 +403,11 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": false
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -648,7 +481,7 @@
       "dependencies": {
         "yaml": {
           "version": "1.10.2",
-          "bundled": true
+          "resolved": false
         }
       }
     },
@@ -1076,25 +909,25 @@
       "dependencies": {
         "jsonschema": {
           "version": "1.4.0",
-          "bundled": true
+          "resolved": false
         },
         "lru-cache": {
           "version": "6.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "semver": {
           "version": "7.3.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true
+          "resolved": false
         }
       }
     },
@@ -1129,19 +962,19 @@
       "dependencies": {
         "@balena/dockerignore": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "at-least-node": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1149,11 +982,11 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": false
         },
         "fs-extra": {
           "version": "9.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
@@ -1163,15 +996,15 @@
         },
         "graceful-fs": {
           "version": "4.2.6",
-          "bundled": true
+          "resolved": false
         },
         "ignore": {
           "version": "5.1.8",
-          "bundled": true
+          "resolved": false
         },
         "jsonfile": {
           "version": "6.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
@@ -1179,14 +1012,14 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "universalify": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         }
       }
     },
@@ -1216,21 +1049,21 @@
       "dependencies": {
         "lru-cache": {
           "version": "6.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "semver": {
           "version": "7.3.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true
+          "resolved": false
         }
       }
     },
@@ -4347,8 +4180,8 @@
     },
     "fsevents": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "resolved": "https://dflds.jfrog.io/dflds/api/npm/npm-dfl/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
       "dev": true,
       "optional": true
     },


### PR DESCRIPTION
# Fix version mismatch

## Description

Package lock version for codecommit was not matching the other CDK versions. The `npm ci` in the workflow is heavily relying on the package lock. The mismatch between versions 1.99 and 1.98 was causing tsc to fail.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

build now works in workflow

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
