### PR TITLE
Rename groupName with poolName in graphql mutation

### DIFF
--- a/lib/api/graphql/schema.graphql
+++ b/lib/api/graphql/schema.graphql
@@ -21,7 +21,7 @@ enum ResultStatus {
 }
 
 input ProcessTestResultInput {
-  groupName: String!
+  poolName: String!
   testResult: String!
 }
 

--- a/lib/api/stack.ts
+++ b/lib/api/stack.ts
@@ -49,7 +49,7 @@ export class ApiStack extends cdk.Stack {
       fieldName: "processTestResult",
       requestMappingTemplate: appsync.MappingTemplate.fromString(
         `
-          $util.qr($ctx.stash.put("groupName", $context.arguments.input.groupName))
+          $util.qr($ctx.stash.put("poolName", $context.arguments.input.poolName))
           $util.qr($ctx.stash.put("testResult", $context.arguments.input.testResult))
           $util.qr($ctx.stash.put("tenant", $context.identity.claims.get("cognito:groups").get(0)))
           {


### PR DESCRIPTION
# Pull Request Template

## Description
The mutation description contains a wrong attribute named groupName. We have to change this to poolName in the graphql schema as well as in the request mapping.

Fixes #23 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Running the kiko-frontend on my localhost and executing functions to process negative and positive test results

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
