### PR TITLE
feat(#26): ignores aws dependencies from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     # Check the npm registry for updates weekly
     schedule:
       interval: "weekly"
+    # Ignore aws-cdk and aws-sdk
+    ignore:
+      - dependency-name: "@aws-cdk/*"
+      - dependency-name: "aws-sdk"


### PR DESCRIPTION
# Pull Request Template

## Description

With this PR dependabot should ignore AWS related npm dependecies, since they have to be updated simultaneously which dependabot is not capable of.

Fixes #26 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested in fork: no PRs were created for AWS dependencies.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
