### PR TITLE
Recipient list management

### DIFF
--- a/bin/kiko.ts
+++ b/bin/kiko.ts
@@ -24,6 +24,7 @@ const tenantManagement = new TenantManagementStack(app, `${deployStage}-kiko-ten
 new ApiStack(app, `${deployStage}-kiko-api`, {
   userPool: tenantManagement.userPool,
   poolTable: poolManagement.poolTable,
+  recipientTable: poolManagement.recipientTable,
   testResultProcessingStateMachine: poolManagement.testResultProcessingStateMachine,
 });
 

--- a/lib/api/graphql/schema.graphql
+++ b/lib/api/graphql/schema.graphql
@@ -7,11 +7,19 @@ type Pool {
 
 type Query {
   listPools: [Pool]
+  listRecipients: [Recipient]
 }
 
 type Result {
   id: ID!
   status: ResultStatus!
+}
+
+type Recipient {
+  tenant: String!
+  address: String!
+  endpointId: String
+  pools: [String]
 }
 
 enum ResultStatus {
@@ -25,6 +33,12 @@ input ProcessTestResultInput {
   testResult: String!
 }
 
+input RecipientInput {
+  address: String!
+  pools: [String]
+}
+
 type Mutation {
   processTestResult(input: ProcessTestResultInput!): Result
+  addRecipient(input: RecipientInput!): Recipient
 }

--- a/lib/api/stack.ts
+++ b/lib/api/stack.ts
@@ -6,17 +6,20 @@ import * as dynamodb from "@aws-cdk/aws-dynamodb";
 import * as sfn from "@aws-cdk/aws-stepfunctions";
 
 interface ApiStackProps extends cdk.StackProps {
+  readonly recipientTable: dynamodb.Table;
   readonly userPool: cognito.UserPool;
   readonly poolTable: dynamodb.Table;
   readonly testResultProcessingStateMachine: sfn.StateMachine;
 }
 
 export class ApiStack extends cdk.Stack {
+  public api: appsync.GraphqlApi;
+
   constructor(scope: cdk.Construct, id: string, props: ApiStackProps) {
     super(scope, id, props);
 
     // Creates the AppSync API
-    const api = new appsync.GraphqlApi(this, "graphql-api", {
+    this.api = new appsync.GraphqlApi(this, "graphql-api", {
       name: "kiko-api",
       schema: appsync.Schema.fromAsset(path.join(__dirname, "graphql", "schema.graphql")),
       authorizationConfig: {
@@ -35,7 +38,7 @@ export class ApiStack extends cdk.Stack {
     });
 
     const stepFunctionEndpoint = `https://states.${this.region}.amazonaws.com`;
-    const stepFunctionDataSource = api.addHttpDataSource("process_test_result", stepFunctionEndpoint, {
+    const stepFunctionDataSource = this.api.addHttpDataSource("process_test_result", stepFunctionEndpoint, {
       authorizationConfig: {
         signingRegion: this.region,
         signingServiceName: "states",
@@ -72,7 +75,9 @@ export class ApiStack extends cdk.Stack {
       responseMappingTemplate: appsync.MappingTemplate.fromString('{"status": "PENDING"}'),
     });
 
-    const dynamoDbDataSource = api.addDynamoDbDataSource("pool_table", props.poolTable);
+    const dynamoDbDataSource = this.api.addDynamoDbDataSource("pool_table", props.poolTable);
+    const recipientTableDataSource = this.api.addDynamoDbDataSource("recipient_table", props.recipientTable);
+
     dynamoDbDataSource.createResolver({
       typeName: "Query",
       fieldName: "listPools",
@@ -93,8 +98,49 @@ export class ApiStack extends cdk.Stack {
       responseMappingTemplate: appsync.MappingTemplate.dynamoDbResultList(),
     });
 
+    recipientTableDataSource.createResolver({
+      typeName: "Query",
+      fieldName: "listRecipients",
+      requestMappingTemplate: appsync.MappingTemplate.fromString(
+        `
+        {
+          "version" : "2017-02-28",
+          "operation" : "Query",
+          "query" : {
+            "expression": "tenant = :tenant",
+              "expressionValues" : {
+                ":tenant" : $util.dynamodb.toDynamoDBJson($context.identity.claims.get("cognito:groups").get(0))
+              }
+          }
+        }
+      `
+      ),
+      responseMappingTemplate: appsync.MappingTemplate.dynamoDbResultList(),
+    });
+
+    recipientTableDataSource.createResolver({
+      typeName: "Mutation",
+      fieldName: "addRecipient",
+      requestMappingTemplate: appsync.MappingTemplate.fromString(
+        `
+        {
+          "version" : "2017-02-28",
+          "operation" : "PutItem",
+          "key" : {
+            "tenant": $util.dynamodb.toDynamoDBJson($context.identity.claims.get("cognito:groups").get(0)),
+            "address": $util.dynamodb.toDynamoDBJson($context.arguments.input.address)
+          },
+          "attributeValues": {
+            "pools" : $util.dynamodb.toDynamoDBJson($context.arguments.input.pools),
+          }
+        }
+      `
+      ),
+      responseMappingTemplate: appsync.MappingTemplate.dynamoDbResultItem(),
+    });
+
     new cdk.CfnOutput(this, "aws-appsync-graphqlEndpoint", {
-      value: api.graphqlUrl,
+      value: this.api.graphqlUrl,
     });
   }
 }

--- a/lib/pool-management/stack.ts
+++ b/lib/pool-management/stack.ts
@@ -11,6 +11,7 @@ interface PoolManagementStackProps extends cdk.StackProps {
 
 export class PoolManagementStack extends cdk.Stack {
   public poolTable: dynamodb.Table;
+  public recipientTable: dynamodb.Table;
   public testResultProcessingStateMachine: sfn.StateMachine;
 
   constructor(scope: cdk.Construct, id: string, props: PoolManagementStackProps) {
@@ -29,6 +30,14 @@ export class PoolManagementStack extends cdk.Stack {
       tableName: `${props.deployStage}-kiko-activity-log`,
       partitionKey: { name: "tenant", type: dynamodb.AttributeType.STRING },
       sortKey: { name: "dateTime", type: dynamodb.AttributeType.STRING },
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+      deployStage: props.deployStage,
+    });
+
+    this.recipientTable = new DynamodbTable(this, "recipients", {
+      tableName: `${props.deployStage}-kiko-test-result-recipients`,
+      partitionKey: { name: "tenant", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "address", type: dynamodb.AttributeType.STRING },
       encryption: dynamodb.TableEncryption.AWS_MANAGED,
       deployStage: props.deployStage,
     });

--- a/test/api/stack.test.ts
+++ b/test/api/stack.test.ts
@@ -1,0 +1,64 @@
+import "@aws-cdk/assert/jest";
+import * as cdk from "@aws-cdk/core";
+import * as fs from "fs";
+import { ApiStack } from "../../lib/api/stack";
+import { PoolManagementStack } from "../../lib/pool-management/stack";
+import { TenantManagementStack } from "../../lib/tenant-management/stack";
+import * as path from "path";
+
+let poolManagementStack: PoolManagementStack;
+let tenantManagementStack: TenantManagementStack;
+let app: cdk.App;
+
+beforeEach(() => {
+  app = new cdk.App({
+    context: {
+      tenants: [],
+    },
+  });
+
+  poolManagementStack = new PoolManagementStack(app, "pool-management", { deployStage: "test" });
+  tenantManagementStack = new TenantManagementStack(app, "tenant-management", {
+    poolTable: poolManagementStack.poolTable,
+    deployStage: "test",
+  });
+});
+
+test("GraphQL APi with name kiko-api is created", () => {
+  const stack = new ApiStack(app, "api", {
+    userPool: tenantManagementStack.userPool,
+    poolTable: poolManagementStack.poolTable,
+    recipientTable: poolManagementStack.recipientTable,
+    testResultProcessingStateMachine: poolManagementStack.testResultProcessingStateMachine,
+  });
+  expect(stack).toHaveResource("AWS::AppSync::GraphQLApi", {
+    Name: "kiko-api",
+  });
+});
+
+test("GraphQL Schema matches source schema definition", async (done) => {
+  const stack = new ApiStack(app, "api", {
+    userPool: tenantManagementStack.userPool,
+    poolTable: poolManagementStack.poolTable,
+    recipientTable: poolManagementStack.recipientTable,
+    testResultProcessingStateMachine: poolManagementStack.testResultProcessingStateMachine,
+  });
+
+  fs.readFile(path.join(__dirname, "../../lib/api/graphql", "schema.graphql"), "utf8", (error, data) => {
+    expect(stack.api.schema.definition).toEqual(data);
+    done();
+  });
+});
+
+test("DynamoDb datasource for recipient list table created", () => {
+  const stack = new ApiStack(app, "api", {
+    userPool: tenantManagementStack.userPool,
+    poolTable: poolManagementStack.poolTable,
+    recipientTable: poolManagementStack.recipientTable,
+    testResultProcessingStateMachine: poolManagementStack.testResultProcessingStateMachine,
+  });
+  expect(stack).toHaveResource("AWS::AppSync::DataSource", {
+    Name: "recipient_table",
+    Type: "AMAZON_DYNAMODB",
+  });
+});

--- a/test/pool-management/stack.test.ts
+++ b/test/pool-management/stack.test.ts
@@ -71,3 +71,31 @@ test("Activity log table is created name {deployStage}-kiko-activity-log", () =>
     TableName: "test-kiko-activity-log",
   });
 });
+
+test("Test result recipient table is created with tenant partition key and address sort key", () => {
+  const app = new cdk.App();
+  const stack = new PoolManagementStack(app, "pool-management", { deployStage: "test" });
+  expect(stack).toHaveResource("AWS::DynamoDB::Table", {
+    TableName: "test-kiko-test-result-recipients",
+    KeySchema: [
+      {
+        AttributeName: "tenant",
+        KeyType: "HASH",
+      },
+      {
+        AttributeName: "address",
+        KeyType: "RANGE",
+      },
+    ],
+    AttributeDefinitions: [
+      {
+        AttributeName: "tenant",
+        AttributeType: "S",
+      },
+      {
+        AttributeName: "address",
+        AttributeType: "S",
+      },
+    ],
+  });
+});


### PR DESCRIPTION
## Description

A very important feature to support onboarding new tenants will be, to give tenant managers the ability to upload and maintain recipient lists for each test pool. Those recipient lists are basically phone numbers we have to add as endpoints into Amazon Pinpoint. We have to keep in mind, that a phone number can be associated to multiple test pools but will be modeled as one endpoint in Pinpoint. A common use case for example in Kindergartens, where a mom or a dad has two kids in different groups.

Test Pool associations are modeled as endpoint attributes in pinpoint. So in a nutshell, a tenant manager must be able to

- add phone numbers
- associate phone numbers to test pools
- delete phone numbers (in case of a request for deletion)

Fixes #39 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
